### PR TITLE
Correcciones

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **APIWeather+JWT** es una aplicación desarrollada en **Node.js** y **Express** que implementa autenticación mediante **JSON Web Tokens (JWT)** y consumo de una **API externa de clima (OpenWeather API)**.  
 El sistema permite a los usuarios autenticarse, obtener un token JWT válido por una hora y utilizarlo para acceder a rutas protegidas que consultan información meteorológica de diferentes ciudades.
 
-Este proyecto cumple con los requisitos técnicos de autenticación, protección de rutas, integración con un servicio externo y manejo adecuado de errores.
+Además, la API incluye un endpoint `/health` para verificar su estado y estadísticas básicas del servidor.
 
 ---
 
@@ -37,6 +37,7 @@ Antes de ejecutar el proyecto, asegúrate de tener instalado:
 3. Crear un archivo `.env` con las siguientes variables:
 
    ```env
+   PORT=3000
    JWT_SECRET=<YOUR_SECRET>
    OPENWEATHER_API_KEY=<YOUR_API_KEY>
    ```
@@ -70,11 +71,12 @@ APIWeather+JWT/
 │   ├── authRoutes.js
 │   └── weatherRoutes.js
 │
+├── utils/
+│   └── users.js
+│   └── client.html
+│
 ├── config/
 │   └── config.js
-│
-├── public/
-│   └── client.html
 │
 ├── app.js
 ├── package.json
@@ -85,18 +87,52 @@ APIWeather+JWT/
 
 ## Endpoints Disponibles
 
-### 1. **POST /auth/login**
+### 1. **GET /**
+
+**Descripción:**  
+Endpoint raíz de verificación.  
+Devuelve un mensaje confirmando que la API está operativa.
+
+**Ejemplo de respuesta (200):**
+```json
+{
+  "message": "APIWeather+JWT is running correctly."
+}
+```
+
+---
+
+### 2. **GET /health**
+
+**Descripción:**  
+Devuelve estadísticas básicas del servidor (uptime, memoria utilizada y puerto activo).
+
+**Ejemplo de respuesta (200):**
+```json
+{
+  "status": "OK",
+  "uptime": "123.45s",
+  "memoryUsage": "32.5 MB",
+  "port": 3000
+}
+```
+
+---
+
+### 3. **POST /auth/login**
 
 **Descripción:**  
 Autentica al usuario y devuelve un JWT válido por 1 hora.
 
-**Credenciales válidas:**
+**Credenciales válidas (por defecto):**
 ```json
 {
   "username": "admin",
   "password": "secret"
 }
 ```
+
+> Las contraseñas se almacenan de forma segura utilizando **bcrypt** para hashing y comparación segura.
 
 **Respuesta exitosa (200):**
 ```json
@@ -106,17 +142,38 @@ Autentica al usuario y devuelve un JWT válido por 1 hora.
 ```
 
 **Errores posibles:**
+- 400 - Usuario o contraseña no proporcionados
 - 401 - Credenciales inválidas
 - 500 - Error interno del servidor
 
 ---
 
-### 2. **GET /weather/:city**
+### 4. **GET /auth/profile**
+
+**Descripción:**  
+Devuelve la información del usuario autenticado, validando el JWT recibido.
+
+**Headers requeridos:**
+```
+Authorization: Bearer <token>
+```
+
+**Ejemplo de respuesta:**
+```json
+{
+  "username": "admin",
+  "role": "user"
+}
+```
+
+---
+
+### 5. **GET /weather/:city**
 
 **Descripción:**  
 Obtiene los datos del clima actual de una ciudad, consultando la API pública de **OpenWeather**.
 
-**Requiere token JWT en el encabezado Authorization:**
+**Headers requeridos:**
 ```
 Authorization: Bearer <token>
 ```
@@ -161,7 +218,7 @@ function authenticateToken(req, res, next) {
   }
 
   jwt.verify(token, jwtSecret, (err, user) => {
-    if (err) return res.status(403).json({ message: 'Token invalido o inesperado.' });
+    if (err) return res.status(403).json({ message: 'Token inválido o expirado.' });
     req.user = user;
     next();
   });
@@ -214,7 +271,7 @@ El archivo `public/client.html` ofrece una interfaz web simple para interactuar 
    El sistema enviará la solicitud con el token JWT en el encabezado y mostrará los datos del clima en pantalla.  
 
 3. **Manejo de errores:**  
-   Si el token expira o la ciudad no existe, se mostrará un mensaje descriptivo en el panel “Detalle”.
+   Si el token expira, la ciudad no existe o falta el token, se mostrará un mensaje descriptivo en el panel “Detalle”.
 
 ---
 
@@ -225,6 +282,7 @@ El servidor devuelve mensajes claros y códigos HTTP adecuados:
 | Código | Descripción |
 |--------|--------------|
 | 200 | Respuesta exitosa |
+| 400 | Faltan datos obligatorios |
 | 401 | Token requerido o credenciales incorrectas |
 | 403 | Token inválido o expirado |
 | 404 | Ciudad no encontrada |
@@ -237,6 +295,7 @@ El servidor devuelve mensajes claros y códigos HTTP adecuados:
 ```json
 "dependencies": {
   "axios": "^1.x",
+  "bcryptjs": "^2.x",
   "dotenv": "^16.x",
   "express": "^4.x",
   "jsonwebtoken": "^9.x",
@@ -249,13 +308,14 @@ El servidor devuelve mensajes claros y códigos HTTP adecuados:
 ## Notas Adicionales
 
 - El token JWT tiene una duración de **1 hora**.  
-- Todas las rutas relacionadas con datos externos están protegidas mediante el middleware JWT.  
+- Las contraseñas se gestionan mediante **bcrypt** para mayor seguridad.  
+- Incluye un endpoint `/health` para verificar el estado del servidor.  
 - Si la conexión con la API de OpenWeather falla, se devuelve un mensaje de error controlado.  
-- El proyecto puede ejecutarse tanto desde **Postman** como desde el **Client.html** incluido.
+- Puede utilizarse desde **Postman** o el **Client.html** incluido.
 
 ---
 
 ## Autor
 
 Proyecto desarrollado por **G. Mirarchi**  
-Examen Técnico: API JWT + OpenWeather (Node.js / Express)
+© 2025 - APIWeather+JWT

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -1,16 +1,48 @@
 const jwt = require('jsonwebtoken');
-const { jwtSecret } = require('../config/config');
+const bcrypt = require('bcrypt');
+const users = require('../utils/users');
+require('dotenv').config();
 
-exports.login = (req, res) => {
-    const {username, password} = req.body;
+exports.login = async (req, res) => {
+  try {
+    const { username, password } = req.body;
 
-    if (username === 'admin' && password === 'secret'){
-        const token = jwt.sign({user: username}, jwtSecret, {expiresIn: '1h'});
-        return res.json({ token })
+    if (!username || !password) {
+      return res.status(400).json({ message: 'Username and password are required' });
     }
-    return res.status(401).json({message: 'Credenciales invalidas'})
-}
+
+    const user = users.find(u => u.username === username);
+
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const isMatch = await bcrypt.compare(password, user.passwordHash);
+    if (!isMatch) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const token = jwt.sign(
+      { username: user.username },
+      process.env.JWT_SECRET,
+      { expiresIn: '1h' }
+    );
+
+    res.json({ token });
+  } catch (error) {
+    console.error('Login error:', error);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+};
 
 exports.profile = (req, res) => {
-    res.json({message: `Bienvenido ${req.user.user}`, user: req.user})
-}
+  try {
+    res.json({
+      message: 'Authenticated user profile',
+      user: req.user,
+    });
+  } catch (error) {
+    console.error('Profile error:', error);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+};

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { port } = require('./config/config')
 const authRoutes = require('./routes/authRoutes')
 const weatherRoutes = require('./routes/weatherRoutes');
+const healthRoutes = require('./routes/healthRoutes');
 const cors = require('cors');
 
 
@@ -10,8 +11,10 @@ const app = express();
 app.use(express.json());
 app.use(cors());
 
+app.use('/', healthRoutes);
 app.use('/auth', authRoutes);
 app.use('/weather', weatherRoutes)
+
 
 app.listen(port, () => {
     console.log(`API working on http://localhost:${port}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^1.12.2",
+        "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
@@ -69,6 +70,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -967,6 +982,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "description": "",
   "dependencies": {
     "axios": "^1.12.2",
+    "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.1.0",

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -1,11 +1,11 @@
 const express = require('express');
-const { login, profile } = require('../controllers/authController');
+const authController = require('../controllers/authController');
 const authenticateToken = require('../middleware/authMiddleware')
 
 const router = express.Router();
 
-router.post('/login', login);
+router.post('/login', authController.login);
 
-router.get('/profile', authenticateToken, profile)
+router.get('/profile', authenticateToken, authController.profile)
 
 module.exports = router;

--- a/routes/healthRoutes.js
+++ b/routes/healthRoutes.js
@@ -1,0 +1,26 @@
+const express = require('express');
+const router = express.Router();
+
+router.get('/', (req, res) => {
+    res.json({
+        message: 'APIWeather+JWT is OK',
+        timestamp: new Date().toISOString()
+    });
+});
+
+router.get('/health', (req, res) => {
+    const memory = process.memoryUsage();
+    res.json({
+        status: 'Ok',
+        uptime: process.uptime(),
+        memory: {
+            rss: memory.rss,
+            heapTotal: memory.heapTotal,
+            heapUsed: memory.heapUsed,
+            external: memory.external
+        },
+        timestamp: new Date().toISOString()
+    });
+});
+
+module.exports = router;

--- a/utils/users.js
+++ b/utils/users.js
@@ -1,0 +1,14 @@
+const bcrypt = require('bcrypt');
+
+const SALT_ROUNDS = 10;
+
+const adminHash = bcrypt.hashSync('secret', SALT_ROUNDS);
+
+const users = [
+  {
+    username: 'admin',
+    passwordHash: adminHash
+  }
+];
+
+module.exports = users;


### PR DESCRIPTION
En el Readme no indicaba que se debe configurar el puerto en el .env, si no se agrega el servicio inicia en `http://localhost:undefined`. 
La api no incluía un GET a la raíz ("/") esto generalmente es importante para saber que la api está funcionando correctamente, mejor todavía si incluye un /health con estadísticas simples como uptime, o consumo de memoria. 
Faltaban validaciones en endpoint de login fuera del html (si no se ingresa usuario y contraseña la app rompe), también las passwords se comprueban directamente en texto plano en lugar de utilizar hashes. 